### PR TITLE
1.6.1

### DIFF
--- a/GatherUp.cs
+++ b/GatherUp.cs
@@ -5,7 +5,7 @@ namespace GatherUp
 {
     public class GatherUp : BotPlugin
     {
-        public static readonly Version version = new Version(1, 6, 0);
+        public static readonly Version version = new Version(1, 6, 1);
         public override string Author => "Parrot";
         public override string Description => "Tool for making orderbot gathering profiles";
         public override Version Version => version;

--- a/HotSpotForm.Designer.cs
+++ b/HotSpotForm.Designer.cs
@@ -44,6 +44,7 @@
             this.radiusNumericUpDown.Name = "radiusNumericUpDown";
             this.radiusNumericUpDown.Size = new System.Drawing.Size(93, 20);
             this.radiusNumericUpDown.TabIndex = 15;
+            this.radiusNumericUpDown.ValueChanged += new System.EventHandler(this.radiusNumericUpDown_ValueChanged_1);
             // 
             // listboxFlyingDest
             // 
@@ -55,6 +56,8 @@
             this.listboxFlyingDest.Name = "listboxFlyingDest";
             this.listboxFlyingDest.Size = new System.Drawing.Size(183, 108);
             this.listboxFlyingDest.TabIndex = 11;
+            this.listboxFlyingDest.SelectedValueChanged += new System.EventHandler(this.listboxFlyingDest_SelectedValueChanged_1);
+            this.listboxFlyingDest.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listboxFlyingDest_KeyDown_1);
             // 
             // btnAddFlyingDest
             // 
@@ -66,6 +69,7 @@
             this.btnAddFlyingDest.TabIndex = 12;
             this.btnAddFlyingDest.Text = "Add flying destination";
             this.btnAddFlyingDest.UseVisualStyleBackColor = true;
+            this.btnAddFlyingDest.Click += new System.EventHandler(this.btnAddFlyingDest_Click);
             // 
             // lblRadius
             // 
@@ -86,6 +90,7 @@
             this.chkboxDisableMount.TabIndex = 10;
             this.chkboxDisableMount.Text = "Disable mount";
             this.chkboxDisableMount.UseVisualStyleBackColor = true;
+            this.chkboxDisableMount.CheckedChanged += new System.EventHandler(this.chkboxDisableMount_CheckedChanged_1);
             // 
             // chkboxLand
             // 
@@ -96,6 +101,7 @@
             this.chkboxLand.TabIndex = 13;
             this.chkboxLand.Text = "Land";
             this.chkboxLand.UseVisualStyleBackColor = true;
+            this.chkboxLand.CheckedChanged += new System.EventHandler(this.chkboxLand_CheckedChanged_1);
             // 
             // HotSpotForm
             // 

--- a/HotSpotForm.cs
+++ b/HotSpotForm.cs
@@ -37,7 +37,7 @@ namespace GatherUp
         }
 
 
-        private void button1_Click(object sender, EventArgs e)
+        private void btnAddFlyingDest_Click(object sender, EventArgs e)
         {
             var position = ff14bot.Core.Player.Location;
             _hotspot.FlyTo.Destinations.Add(new FlyTo.Destination
@@ -52,31 +52,8 @@ namespace GatherUp
                 break;
             }
         }
-        
-        private void chkboxLand_CheckedChanged(object sender, EventArgs e)
-        {
-            var destination = (FlyTo.Destination) listboxFlyingDest.SelectedItem;
-            if (destination == null)
-            {
-                chkboxLand.Checked = false;
-                return;
-            }
 
-            destination.Land = chkboxLand.Checked;
-
-        }
-
-        private void chkboxDisableMount_CheckedChanged(object sender, EventArgs e)
-        {
-            _hotspot.DisableMount = chkboxDisableMount.Checked;
-        }
-
-        private void listboxFlyingDest_SelectedValueChanged(object sender, EventArgs e)
-        {
-            chkboxLand.Checked = ((FlyTo.Destination)listboxFlyingDest.SelectedItem)?.Land ?? false;
-        }
-
-        private void listboxFlyingDest_KeyDown(object sender, KeyEventArgs e)
+        private void listboxFlyingDest_KeyDown_1(object sender, KeyEventArgs e)
         {
             if (listboxFlyingDest.SelectedItem == null) return;
             if (e.KeyCode != Keys.Delete) return;
@@ -85,7 +62,29 @@ namespace GatherUp
             RefreshForm();
         }
 
-        private void radiusNumericUpDown_ValueChanged(object sender, EventArgs e)
+        private void listboxFlyingDest_SelectedValueChanged_1(object sender, EventArgs e)
+        {
+            chkboxLand.Checked = ((FlyTo.Destination)listboxFlyingDest.SelectedItem)?.Land ?? false;
+        }
+
+        private void chkboxDisableMount_CheckedChanged_1(object sender, EventArgs e)
+        {
+            _hotspot.DisableMount = chkboxDisableMount.Checked;
+        }
+
+        private void chkboxLand_CheckedChanged_1(object sender, EventArgs e)
+        {
+            var destination = (FlyTo.Destination)listboxFlyingDest.SelectedItem;
+            if (destination == null)
+            {
+                chkboxLand.Checked = false;
+                return;
+            }
+
+            destination.Land = chkboxLand.Checked;
+        }
+
+        private void radiusNumericUpDown_ValueChanged_1(object sender, EventArgs e)
         {
             _hotspot.Radius = (int)radiusNumericUpDown.Value;
         }

--- a/Order/Profile.cs
+++ b/Order/Profile.cs
@@ -51,7 +51,7 @@ namespace GatherUp.Order
             {
                 public Vector3 Position { get; set; }
                 public double AllowedVariance { get; set; } = 0.0f;
-                public bool Land { get; set; } = true;
+                public bool Land { get; set; } = false;
 
                 public string GetXYZ()
                 {


### PR DESCRIPTION
Editor mishap caused events for the hotspot edit form controls to stop working. Fixed.

The landing value for flyto tags is now turned off by default.